### PR TITLE
Message handler disabled command logic

### DIFF
--- a/handler/message.js
+++ b/handler/message.js
@@ -126,7 +126,9 @@ async function message(client, channel, tags, message) {
         }
     }
 
-    if(commandEnabled == 0) {
+    // Convert commandEnabled to number and check if disabled (handles string "0", "1", null, undefined)
+    commandEnabled = commandEnabled === null || commandEnabled === undefined ? 0 : parseInt(commandEnabled, 10);
+    if(commandEnabled === 0 || isNaN(commandEnabled)) {
         return;
     }
     


### PR DESCRIPTION
Correctly parse `commandEnabled` from Redis to prevent disabled commands from executing.

The `commandEnabled` value retrieved from Redis could be a string (`"0"`, `"1"`) or `null`. The previous comparison `commandEnabled == 0` failed to correctly identify `null` as a disabled state (`null == 0` evaluates to `false`), allowing disabled commands to run. This fix explicitly converts the value to a number, treating `null`/`undefined` as `0` (disabled), and handles `NaN` for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1f222fc-3704-4aa0-b732-3e840b6fd402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1f222fc-3704-4aa0-b732-3e840b6fd402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

