### PR TITLE
Command enablement cache check

### DIFF
--- a/command/disablecommand.js
+++ b/command/disablecommand.js
@@ -26,8 +26,12 @@ async function disableCommand (channelID, argument) {
 
     await command.save();
 
-    // Delete the entire command from cache to force a fresh fetch
-    await cacheClient.del(`${channelID}:commands:${argument}`);
+    // Update cache to mark command as disabled
+    let exists = await cacheClient.exists(`${channelID}:commands:${argument}`);
+    
+    if(exists) {
+        await cacheClient.hset(`${channelID}:commands:${argument}`, 'enabled', 'false');
+    }
     
     return {
         error: false,

--- a/command/enablecommand.js
+++ b/command/enablecommand.js
@@ -28,7 +28,7 @@ async function enableCommand (channelID, argument) {
     let exists = await cacheClient.exists(`${channelID}:commands:${argument}`);
     
     if(exists) {
-        await cacheClient.hset(`${channelID}:commands:${argument}`, 'enabled', 1);
+        await cacheClient.hset(`${channelID}:commands:${argument}`, 'enabled', 'true');
     }
 
     await command.save();

--- a/handler/message.js
+++ b/handler/message.js
@@ -102,33 +102,40 @@ async function message(client, channel, tags, message) {
                 func: 'none',
                 level: 0,
                 cooldown: 0,
-                enabled: 0
+                enabled: 'false'
             }
             // Saves non existing command to cache as disabled
             await cacheClient.hset(`${channelID}:commands:${command}`, cacheCommandData);
             commandFunc = 'none';
             commandUserLevel = 0;
             commandCD = 0;
-            commandEnabled = 0;
+            commandEnabled = 'false';
         } else {
             let cacheCommandData = {
                 func: commandData.func,
                 level: commandData.userLevel,
                 cooldown: commandData.cooldown,
-                enabled: commandData.enabled ? 1 : 0
+                enabled: commandData.enabled ? 'true' : 'false'
             }
             // Saves command to cache
             await cacheClient.hset(`${channelID}:commands:${command}`, cacheCommandData);
             commandFunc = commandData.func;
             commandUserLevel = commandData.userLevel;
             commandCD = commandData.cooldown;
-            commandEnabled = commandData.enabled ? 1 : 0;
+            commandEnabled = commandData.enabled ? 'true' : 'false';
         }
     }
 
-    // Convert commandEnabled to number and check if disabled (handles string "0", "1", null, undefined)
-    commandEnabled = commandEnabled === null || commandEnabled === undefined ? 0 : parseInt(commandEnabled, 10);
-    if(commandEnabled === 0 || isNaN(commandEnabled)) {
+    // Check if command is enabled (handles string "true"/"false", "0"/"1", boolean, null, undefined)
+    if(commandEnabled === null || commandEnabled === undefined) {
+        return;
+    }
+    
+    // Convert to string for comparison (handles both string and number values from cache)
+    const enabledStr = String(commandEnabled).toLowerCase().trim();
+    
+    // Only proceed if enabled is "true" or "1", otherwise return early
+    if(enabledStr !== 'true' && enabledStr !== '1') {
         return;
     }
     

--- a/handler_function/addcommandstocache.js
+++ b/handler_function/addcommandstocache.js
@@ -17,7 +17,7 @@ async function addCommandsToCache(channelID) {
             func: commands[i].func,
             level: commands[i].userLevel,
             cooldown: commands[i].cooldown,
-            enabled: commands[i].enabled,
+            enabled: commands[i].enabled ? 'true' : 'false',
         }
 
         try {


### PR DESCRIPTION
Standardize command enablement in cache to 'true'/'false' strings and update the message handler to correctly enforce command execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ffe04b8-87d8-4f4a-9eae-415ec20f5f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ffe04b8-87d8-4f4a-9eae-415ec20f5f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

